### PR TITLE
fix: Replace LambdaTest brand name with TestMu AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Run SmartUI Cypress Tests on TestMu AI (Formerly LambdaTest)
+﻿# Run SmartUI Cypress Tests on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
@@ -30,7 +30,7 @@ git clone https://github.com/LambdaTest/smartui-cypress-sample
 cd smartui-cypress-sample
 ```
 
-Install the LambdaTest Cypress CLI globally:
+Install the TestMu AI (Formerly LambdaTest) Cypress CLI globally:
 
 ```bash
 npm install -g lambdatest-cypress-cli


### PR DESCRIPTION
Replaces all standalone LambdaTest brand mentions with TestMu AI (Formerly LambdaTest) in body text and TestMu AI in H1 title. Code blocks, URLs, badge HTML, and boilerplate are untouched.